### PR TITLE
🩹 registerPet*: block access from logined user

### DIFF
--- a/src/pages/registerPetOwner.tsx
+++ b/src/pages/registerPetOwner.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
-import type { NextPage } from "next";
+import type {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  NextPage,
+} from "next";
 import { api } from "../utils/api";
 import {
   type FieldErrorsImpl,
@@ -12,6 +16,7 @@ import Header from "../components/Header";
 import { useState } from "react";
 import { signIn } from "next-auth/react";
 import { useRouter } from "next/router";
+import { getServerAuthSession } from "../server/auth";
 
 // Schema for first page of form
 const formDataSchema1 = z.object({
@@ -439,3 +444,19 @@ const Button: React.FC<ButtonProps> = ({ children, ...props }) => (
 );
 
 export default RegisterPage;
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  // Redirect to home page if user is already logged in
+  const session = await getServerAuthSession(ctx);
+  if (session) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  // Default return
+  return { props: {} };
+}

--- a/src/pages/registerPetSitter.tsx
+++ b/src/pages/registerPetSitter.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useState } from "react";
-import type { NextPage } from "next";
+import type { GetServerSidePropsContext, NextPage } from "next";
 import { api } from "../utils/api";
 import {
   FieldValues,
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { PetKind } from "@prisma/client";
 import Header from "../components/Header";
 import { useRouter } from "next/router";
+import { getServerAuthSession } from "../server/auth";
 
 export default function RegisterPetSitter() {
   const createFreelancePetSitter = api.freelancePetSitter.create.useMutation();
@@ -577,3 +578,19 @@ const Input: React.FC<InputProps> = ({
     />
   </>
 );
+
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
+  // Redirect to home page if user is already logged in
+  const session = await getServerAuthSession(ctx);
+  if (session) {
+    return {
+      redirect: {
+        destination: "/",
+        permanent: false,
+      },
+    };
+  }
+
+  // Default return
+  return { props: {} };
+}


### PR DESCRIPTION
<!--
This is a template for a pull request. replace each section with your own information.
You may also add additional sections if you feel they are relevant, or remove sections that are not relevant.
-->

## Description
Add guard logic that prevent logined user from accessing register page (frontend-wise), attempt to do so will br redirected out to frontpage.

## Demo
As logined user, try access register page (either with direct url typing & redirect after login), it should be good.

## Testing
- Access login page when not logined (able)
- Access login page after logined (not able, redirected)
- Goto register then login (login redirected back to home page, not reigster page)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have merge/rebased the latest changes from the target branch (usually `dev`) into my branch, and resolved any conflicts that may have arisen
- [x] After the previous step, I have regenerated artifacts (run `npm i`) and committed the changes
- [x] I have checked my code and corrected any misspellings
- [ ] I have add any relevent labels to this PR
